### PR TITLE
Adding support for Minecraft 1.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'eclipse'
 apply plugin: 'groovy'
-//apply plugin: 'signing'
+apply plugin: 'signing'
 apply plugin: 'maven'
 
 group = 'com.github.abrarsyed.gmcp'
@@ -87,16 +87,16 @@ artifacts {
 uploadArchives {
     repositories.mavenDeployer {
 
-        //beforeDeployment { MavenDeployment deployment ->
-        //    signing.signPom(deployment)
-        //}
+        beforeDeployment { MavenDeployment deployment ->
+            signing.signPom(deployment)
+        }
 
-        //snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots") {
-        //    authentication(userName: sonatypeUsername, password: sonatypePassword)
-        //}
+        snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots") {
+            authentication(userName: sonatypeUsername, password: sonatypePassword)
+        }
 
         // local testing only.
-        snapshotRepository(url: "file://C:/Users/sebastian/.m2/repository/")
+        // snapshotRepository(url: "file://C:/Users/sebastian/.m2/repository/")
 
         repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2") {
             authentication(userName: sonatypeUsername, password: sonatypePassword)

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'eclipse'
 apply plugin: 'groovy'
-apply plugin: 'signing'
+//apply plugin: 'signing'
 apply plugin: 'maven'
 
 group = 'com.github.abrarsyed.gmcp'
@@ -82,21 +82,21 @@ artifacts {
     archives sourcesJar
 }
 
-signing { sign configurations.archives }
+//signing { sign configurations.archives }
 
 uploadArchives {
     repositories.mavenDeployer {
 
-        beforeDeployment { MavenDeployment deployment ->
-            signing.signPom(deployment)
-        }
+        //beforeDeployment { MavenDeployment deployment ->
+        //    signing.signPom(deployment)
+        //}
 
-        snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots") {
-            authentication(userName: sonatypeUsername, password: sonatypePassword)
-        }
+        //snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots") {
+        //    authentication(userName: sonatypeUsername, password: sonatypePassword)
+        //}
 
-//        // local testing only.
-//        snapshotRepository(url: "file://D:/Users/AbrarSyed/EclipseWorkspace/MavenRepo")
+        // local testing only.
+        snapshotRepository(url: "file://C:/Users/sebastian/.m2/repository/")
 
         repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2") {
             authentication(userName: sonatypeUsername, password: sonatypePassword)

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ artifacts {
     archives sourcesJar
 }
 
-//signing { sign configurations.archives }
+signing { sign configurations.archives }
 
 uploadArchives {
     repositories.mavenDeployer {

--- a/src/main/groovy/com/github/abrarsyed/gmcp/Constants.groovy
+++ b/src/main/groovy/com/github/abrarsyed/gmcp/Constants.groovy
@@ -34,7 +34,9 @@ public final class Constants
     // download URLs
     public static final String	URL_JSON_FORGE 		= "http://files.minecraftforge.net/minecraftforge/json"
     public static final String  URL_JSON_FORGE2     = "http://files.minecraftforge.net/minecraftforge/json2"
-    public static final String  URL_JSON_MC16       = 'http://s3.amazonaws.com/Minecraft.Download/versions/%1$s/%1$s.json'
+    public static final String  URL_JSON_FML        = 'https://raw.github.com/MinecraftForge/FML/master/jsons/%1$s-dev.json'
+    public static final String  URL_MC16_CLIENT     = 'http://s3.amazonaws.com/Minecraft.Download/versions/%1$s/%1$s.jar'
+    public static final String  URL_MC16_SERVER     = 'http://s3.amazonaws.com/Minecraft.Download/versions/%1$s/minecraft_server.%1$s.jar'
 
     // cache file paths
     public static final String  CACHE_JSON_FORGE    = "caches/gmcp/forge.json"

--- a/src/main/groovy/com/github/abrarsyed/gmcp/Constants.groovy
+++ b/src/main/groovy/com/github/abrarsyed/gmcp/Constants.groovy
@@ -22,6 +22,7 @@ public final class Constants
 
     // stuff in the jars folder
     static final String  	DIR_JAR_BIN 	    	= "bin"
+    static final String  	DIR_JAR_BIN_NATIVES     = DIR_JAR_BIN + "/natives"
     static final String 	JAR_JAR_CLIENT	    	= DIR_JAR_BIN + "/minecraft.jar"
     static final String     JAR_JAR_CLIENT_BAK      = DIR_JAR_BIN + "/minecraft.jar.bak"
     static final String 	JAR_JAR_SERVER	 	    = "minecraft_server.jar"

--- a/src/main/groovy/com/github/abrarsyed/gmcp/GMCP.groovy
+++ b/src/main/groovy/com/github/abrarsyed/gmcp/GMCP.groovy
@@ -1,6 +1,6 @@
 package com.github.abrarsyed.gmcp
 
-import groovy.json.JsonSlurper
+import com.github.abrarsyed.gmcp.mcversion.McVersionInfo
 
 import static com.github.abrarsyed.gmcp.Util.baseFile
 import static com.github.abrarsyed.gmcp.Util.jarFile
@@ -125,9 +125,19 @@ public class GMCP implements Plugin<Project>
                         // 1.6.2+
                         // Download the information file for the version we are about to DL
                         // Example: https://s3.amazonaws.com/Minecraft.Download/versions/1.6.2/1.6.2.json
-                        def slurper = new JsonSlurper()
-                        def versionInfo
+                        def versionInfoUrl = new URL(String.format(Constants.URL_JSON_MC16, mcver))
+                        logger.debug("Loading Minecraft version information from {}", versionInfoUrl)
+                        def versionInfo = McVersionInfo.parse(versionInfoUrl)
 
+                        for (lib in versionInfo.libraries) {
+                            if (!lib.allowed) {
+                                logger.debug("Skipping Minecraft library {} because it does not apply to this system", lib.name)
+                            } else {
+                                // TODO: Respect the extract / native stuff
+                                logger.debug("Adding dependency on {}", lib.name)
+                                gmcp lib.name
+                            }
+                        }
 
                     }
                 }

--- a/src/main/groovy/com/github/abrarsyed/gmcp/GMCP.groovy
+++ b/src/main/groovy/com/github/abrarsyed/gmcp/GMCP.groovy
@@ -1,5 +1,7 @@
 package com.github.abrarsyed.gmcp
 
+import groovy.json.JsonSlurper
+
 import static com.github.abrarsyed.gmcp.Util.baseFile
 import static com.github.abrarsyed.gmcp.Util.jarFile
 import static com.github.abrarsyed.gmcp.Util.srcFile
@@ -121,8 +123,12 @@ public class GMCP implements Plugin<Project>
                     else
                     {
                         // 1.6.2+
+                        // Download the information file for the version we are about to DL
+                        // Example: https://s3.amazonaws.com/Minecraft.Download/versions/1.6.2/1.6.2.json
+                        def slurper = new JsonSlurper()
+                        def versionInfo
 
-                        // TODO: read JSON here
+
                     }
                 }
 

--- a/src/main/groovy/com/github/abrarsyed/gmcp/GMCP.groovy
+++ b/src/main/groovy/com/github/abrarsyed/gmcp/GMCP.groovy
@@ -89,10 +89,6 @@ public class GMCP implements Plugin<Project>
                 def mcver = minecraft.minecraftVersion
                 def is152Minus = minecraft.is152OrLess()
 
-                // for only 0.5, crash on more than 1.5.2
-                //                if (!is152Minus)
-                //                    throw new RuntimeException('GMCP 0.5 only supports Minecraft 1.5.2 or lower!')
-
                 // yay for maven central.
                 repositories {
 
@@ -117,19 +113,21 @@ public class GMCP implements Plugin<Project>
                             gmcp dep
                         }
 
-                        gmcp fileTree(dir:jarFile(Constants.DIR_JAR_BIN), include: "*.jar")
-
                     }
                     else
                     {
                         // 1.6.2+
-                        // Download the information file for the version we are about to DL
-                        // Example: https://s3.amazonaws.com/Minecraft.Download/versions/1.6.2/1.6.2.json
-                        def versionInfoUrl = new URL(String.format(Constants.URL_JSON_MC16, mcver))
-                        logger.debug("Loading Minecraft version information from {}", versionInfoUrl)
-                        def versionInfo = McVersionInfo.parse(versionInfoUrl)
+                        // FML seems to replicate the requirements that Minecraft also states,
+                        // so we parse FML's JSON file for dependencies instead of merging the two
+                        def fmlJsonUrl = new URL(String.format(Constants.URL_JSON_FML, mcver))
+                        def versionInfo = McVersionInfo.parse(fmlJsonUrl)
 
                         for (lib in versionInfo.libraries) {
+
+                            // Gradle really really doesnt like broken POMs
+                            if (lib.name.equals("net.sourceforge.argo:argo:2.25"))
+                                continue
+
                             if (!lib.allowed) {
                                 logger.debug("Skipping Minecraft library {} because it does not apply to this system", lib.name)
                             } else {
@@ -140,6 +138,9 @@ public class GMCP implements Plugin<Project>
                         }
 
                     }
+
+                    gmcp fileTree(dir:jarFile(Constants.DIR_JAR_BIN), include: "*.jar")
+
                 }
 
                 // eclipse specific native stuff
@@ -268,21 +269,32 @@ public class GMCP implements Plugin<Project>
             def baseUrl = parser.getProperty("default", "base_url")
 
             def mcver = parser.getProperty("default", "current_ver")
-            Util.download(parser.getProperty(mcver, "client_url"), jarFile(Constants.JAR_JAR_CLIENT_BAK))
-            Util.download(parser.getProperty(mcver, "server_url"), jarFile(Constants.JAR_JAR_SERVER))
 
-            def dls = parser.getProperty("default", "libraries").split(/\s/)
-            dls.each { Util.download(baseUrl+it, new File(root, it)) }
+            // FML no longer provides a download URL for 1.6.2 and later
+            if (project.minecraft.is152OrLess()) {
+                Util.download(parser.getProperty(mcver, "client_url"), jarFile(Constants.JAR_JAR_CLIENT_BAK))
+                Util.download(parser.getProperty(mcver, "server_url"), jarFile(Constants.JAR_JAR_SERVER))
 
-            def nativesJar = Util.file(temporaryDir, "natives.jar")
-            def nativesName = parser.getProperty("default", "natives").split(/\s/)[os.ordinal()]
-            Util.download(baseUrl + nativesName, nativesJar)
+                def dls = parser.getProperty("default", "libraries").split(/\s/)
+                dls.each { Util.download(baseUrl+it, new File(root, it)) }
 
-            project.copy {
-                from project.zipTree(nativesJar)
-                exclude 'META-INF'
-                into Util.file(root, "natives")
+                def nativesJar = Util.file(temporaryDir, "natives.jar")
+                def nativesName = parser.getProperty("default", "natives").split(/\s/)[os.ordinal()]
+                Util.download(baseUrl + nativesName, nativesJar)
+
+                project.copy {
+                    from project.zipTree(nativesJar)
+                    exclude 'META-INF'
+                    into Util.file(root, "natives")
+                }
+            } else {
+                // For 1.6.2 we have to build the URLs ourselves
+                def clientUrl = String.format(Constants.URL_MC16_CLIENT, mcver)
+                Util.download(clientUrl, jarFile(Constants.JAR_JAR_CLIENT_BAK))
+                def serverUrl = String.format(Constants.URL_MC16_SERVER, mcver)
+                Util.download(serverUrl, jarFile(Constants.JAR_JAR_SERVER))
             }
+
         }
 
         // ----------------------------------------------------------------------------
@@ -375,15 +387,12 @@ public class GMCP implements Plugin<Project>
         // merge jars
         task << {
             def server = Util.file(temporaryDir, "server.jar")
-            def merged = jarFile(Constants.JAR_JAR_CLIENT)
             def mergeTemp = Util.file(temporaryDir, "merged.jar.tmp")
 
             Files.copy(jarFile(Constants.JAR_JAR_CLIENT_BAK), mergeTemp)
             Files.copy(jarFile(Constants.JAR_JAR_SERVER), server)
 
-            logger.lifecycle "Merging jars"
-
-            //Constants.JAR_CLIENT, Constants.JAR_SERVER
+            logger.lifecycle "Merging client and server jars"
             def args = [
                 baseFile(Constants.DIR_FML, "mcp_merge.cfg").getPath(),
                 mergeTemp.getPath(),
@@ -391,7 +400,9 @@ public class GMCP implements Plugin<Project>
             ]
             MCPMerger.main(args as String[])
 
-            // copy and strip METAINF
+            // Make a copy of the merged JAR (still obfuscated) while stripping out META-INF (signatures)
+            logger.lifecycle "Copying merged jar without signatures"
+            def merged = jarFile(Constants.JAR_JAR_CLIENT)
             def ZipFile input = new ZipFile(mergeTemp)
             def output = new ZipOutputStream(merged.newDataOutputStream())
 
@@ -411,7 +422,6 @@ public class GMCP implements Plugin<Project>
         }
         // deobfuscate---------------------------
         task << {
-            def merged = jarFile(Constants.JAR_JAR_CLIENT)
             def deobf = Util.file(temporaryDir, "deobf.jar")
 
             logger.lifecycle "DeObfuscating jar"
@@ -427,13 +437,13 @@ public class GMCP implements Plugin<Project>
             project.minecraft.accessTransformers.collect {
                 accessMap.loadAccessTransformer(project.file(Constants.DIR_FORGE, "common/forge_at.cfg"))
             }
-            def processor = new  RemapperPreprocessor(null, mapping, accessMap)
+            def processor = new RemapperPreprocessor(null, mapping, accessMap)
 
             // make remapper
             JarRemapper remapper = new JarRemapper(processor, mapping)
 
-            // load jar
-            Jar input = Jar.init(merged)
+            // load merged jar (still obfuscated, no signatures)
+            Jar input = Jar.init(jarFile(Constants.JAR_JAR_CLIENT))
 
             // ensure that inheritance provider is used
             JointProvider inheritanceProviders = new JointProvider()

--- a/src/main/groovy/com/github/abrarsyed/gmcp/mcversion/McLibraryDependency.groovy
+++ b/src/main/groovy/com/github/abrarsyed/gmcp/mcversion/McLibraryDependency.groovy
@@ -1,0 +1,33 @@
+package com.github.abrarsyed.gmcp.mcversion
+
+class McLibraryDependency {
+
+    String name
+
+    List<McLibraryRule> rules = new ArrayList<McLibraryRule>()
+
+    /**
+     * Tests whether this dependency is excluded because it has matching disallow rules
+     * @return
+     */
+    boolean isAllowed() {
+
+        if (rules.isEmpty())
+            return true
+
+        def allowed = true
+
+        for (rule in rules) {
+            allowed &= rule.allowed
+        }
+
+        return allowed
+
+    }
+
+    @Override
+    String toString() {
+        name
+    }
+
+}

--- a/src/main/groovy/com/github/abrarsyed/gmcp/mcversion/McLibraryDependency.groovy
+++ b/src/main/groovy/com/github/abrarsyed/gmcp/mcversion/McLibraryDependency.groovy
@@ -6,6 +6,10 @@ class McLibraryDependency {
 
     List<McLibraryRule> rules = new ArrayList<McLibraryRule>()
 
+    McLibraryNatives natives = null
+
+    McLibraryExtract extract = null
+
     /**
      * Tests whether this dependency is excluded because it has matching disallow rules
      * @return

--- a/src/main/groovy/com/github/abrarsyed/gmcp/mcversion/McLibraryExtract.groovy
+++ b/src/main/groovy/com/github/abrarsyed/gmcp/mcversion/McLibraryExtract.groovy
@@ -1,0 +1,10 @@
+package com.github.abrarsyed.gmcp.mcversion
+
+/**
+ * Indicates that a library needs to be extract and not be depended upon
+ */
+class McLibraryExtract {
+
+    List<String> exclude = new ArrayList<>() // Exclude list
+
+}

--- a/src/main/groovy/com/github/abrarsyed/gmcp/mcversion/McLibraryNatives.groovy
+++ b/src/main/groovy/com/github/abrarsyed/gmcp/mcversion/McLibraryNatives.groovy
@@ -1,0 +1,23 @@
+package com.github.abrarsyed.gmcp.mcversion
+
+import com.github.abrarsyed.gmcp.Constants
+
+class McLibraryNatives {
+
+    String windows
+
+    String linux
+
+    String osx
+
+    def getNative(Constants.OperatingSystem operatingSystem) {
+        switch (operatingSystem) {
+            case Constants.OperatingSystem.WINDOWS:
+                return windows
+            case Constants.OperatingSystem.MAC:
+                return osx
+            case Constants.OperatingSystem.LINUX:
+                return linux
+        }
+    }
+}

--- a/src/main/groovy/com/github/abrarsyed/gmcp/mcversion/McLibraryRule.groovy
+++ b/src/main/groovy/com/github/abrarsyed/gmcp/mcversion/McLibraryRule.groovy
@@ -1,0 +1,18 @@
+package com.github.abrarsyed.gmcp.mcversion
+
+class McLibraryRule {
+
+    String action
+
+    McLibraryRuleOs os
+
+    boolean isAllowed() {
+        def matches = os == null || os.match
+
+        if (action == "allow")
+            return matches
+        else
+            return !matches
+    }
+
+}

--- a/src/main/groovy/com/github/abrarsyed/gmcp/mcversion/McLibraryRuleOs.groovy
+++ b/src/main/groovy/com/github/abrarsyed/gmcp/mcversion/McLibraryRuleOs.groovy
@@ -1,0 +1,40 @@
+package com.github.abrarsyed.gmcp.mcversion
+
+import com.github.abrarsyed.gmcp.Constants
+import com.github.abrarsyed.gmcp.Util
+
+import java.util.regex.Pattern
+
+/**
+ * A rule specification that applies to the operating system of this computer
+ */
+class McLibraryRuleOs {
+
+    String name
+
+    Pattern versionPattern
+
+    McLibraryRuleOs(String name, String version) {
+        this.name = name
+        this.versionPattern = Pattern.compile(version);
+    }
+
+    boolean isMatch() {
+        switch (Util.OS) {
+            case Constants.OperatingSystem.WINDOWS:
+                return name == "windows" && isVersionMatch()
+            case Constants.OperatingSystem.MAC:
+                return name == "osx" && isVersionMatch()
+            case Constants.OperatingSystem.LINUX:
+                return name == "linux" && isVersionMatch()
+            default:
+                return false
+        }
+    }
+
+    boolean isVersionMatch() {
+        def version = System.getProperty("os.version")
+        return versionPattern.matcher(version).matches();
+    }
+
+}

--- a/src/main/groovy/com/github/abrarsyed/gmcp/mcversion/McVersionInfo.groovy
+++ b/src/main/groovy/com/github/abrarsyed/gmcp/mcversion/McVersionInfo.groovy
@@ -85,6 +85,24 @@ class McVersionInfo {
             def library = new McLibraryDependency()
             library.name = jsonLibrary["name"] // This is a Maven-style artifact reference
 
+            def jsonNatives = jsonLibrary["natives"]
+            if (jsonNatives != null) {
+                def natives = new McLibraryNatives()
+                natives.windows = jsonNatives["windows"]
+                natives.linux = jsonNatives["linux"]
+                natives.osx = jsonNatives["osx"]
+                library.natives = natives
+            }
+
+            def jsonExtract = jsonLibrary["extract"]
+            if (jsonExtract != null) {
+                def extract = new McLibraryExtract()
+                if (jsonExtract["exclude"] != null) {
+                    extract.exclude = jsonExtract["exclude"]
+                }
+                library.extract = extract
+            }
+
             // There are "rules" that pull in other versions of the libraries for different OS versions
             // Currently it seems to be used to pull in a nightly-build of lwjgl for certain MacOS versions
             def jsonRules = jsonLibrary["rules"]

--- a/src/main/groovy/com/github/abrarsyed/gmcp/mcversion/McVersionInfo.groovy
+++ b/src/main/groovy/com/github/abrarsyed/gmcp/mcversion/McVersionInfo.groovy
@@ -1,0 +1,105 @@
+package com.github.abrarsyed.gmcp.mcversion
+
+import com.google.common.base.Charsets
+import com.google.common.io.Resources
+import groovy.json.JsonSlurper
+
+import javax.xml.bind.DatatypeConverter
+
+/**
+ * Parses the Minecraft JSON information file used to describe a Minecraft version.
+ *
+ * Example: https://s3.amazonaws.com/Minecraft.Download/versions/1.6.2/1.6.2.json
+ */
+class McVersionInfo {
+
+    String id
+
+    Calendar time
+
+    Calendar releaseTime
+
+    String type
+
+    String processArguments
+
+    String minecraftArguments
+
+    int minimumLauncherVersion
+
+    List<McLibraryDependency> libraries
+
+    String mainClass
+
+    static def parse(URL url) {
+        try {
+            return parse(Resources.toString(url, Charsets.UTF_8));
+        } catch (IOException e) {
+            throw new IOException("Unable to access the Minecraft Version information @ " + url, e);
+        }
+    }
+
+    static def parse(String jsonText) {
+
+        def slurper = new JsonSlurper()
+        def jsonInfo = slurper.parseText(jsonText)
+
+        def result = new McVersionInfo()
+
+        result.id = (String) jsonInfo["id"]
+        result.time = parseDate((String) jsonInfo["time"])
+        result.releaseTime = parseDate((String) jsonInfo["releaseTime"])
+        result.type = (String) jsonInfo["type"]
+        result.processArguments = (String) jsonInfo["processArguments"]
+        result.minecraftArguments = (String) jsonInfo["minecraftArguments"]
+        result.minimumLauncherVersion = (int) jsonInfo["minimumLauncherVersion"]
+        result.libraries = parseLibraries(jsonInfo["libraries"])
+        result.mainClass = (String) jsonInfo["mainClass"]
+
+        result
+    }
+
+    static def parseDate(String dateString) {
+        // Java date handling isn't great. Especially since SimpleDateFormat can't handle ISO compliant time stamps
+        return DatatypeConverter.parseDateTime(dateString);
+    }
+
+    static def parseLibraries(def jsonLibraries) {
+
+        def result = new ArrayList<McLibraryDependency>();
+
+        for (jsonLibrary in jsonLibraries) {
+            def library = new McLibraryDependency()
+            library.name = jsonLibrary["name"] // This is a Maven-style artifact reference
+
+            // There are "rules" that pull in other versions of the libraries for different OS versions
+            // Currently it seems to be used to pull in a nightly-build of lwjgl for certain MacOS versions
+            def jsonRules = jsonLibrary["rules"]
+            if (jsonRules != null) {
+                for (jsonRule in jsonRules) {
+                    def rule = new McLibraryRule()
+                    rule.action = jsonRule["action"]
+                    if (jsonRule["os"]) {
+                        def ruleOs = new McLibraryRuleOs(
+                                (String) jsonRule["os"]["name"],
+                                (String) jsonRule["os"]["version"]
+                        )
+                        rule.os = ruleOs
+                    }
+                    library.rules.add(rule)
+                }
+            }
+
+            result.add(library)
+        }
+
+        return result
+
+    }
+
+    @Override
+    public String toString() {
+        return id
+    }
+
+}

--- a/src/main/groovy/com/github/abrarsyed/gmcp/mcversion/McVersionInfo.groovy
+++ b/src/main/groovy/com/github/abrarsyed/gmcp/mcversion/McVersionInfo.groovy
@@ -1,6 +1,7 @@
 package com.github.abrarsyed.gmcp.mcversion
 
 import com.google.common.base.Charsets
+import com.google.common.io.Files
 import com.google.common.io.Resources
 import groovy.json.JsonSlurper
 
@@ -31,6 +32,10 @@ class McVersionInfo {
 
     String mainClass
 
+    static def parse(File file) {
+        return parse(Files.toString(file, Charsets.UTF_8))
+    }
+
     static def parse(URL url) {
         try {
             return parse(Resources.toString(url, Charsets.UTF_8));
@@ -47,8 +52,16 @@ class McVersionInfo {
         def result = new McVersionInfo()
 
         result.id = (String) jsonInfo["id"]
-        result.time = parseDate((String) jsonInfo["time"])
-        result.releaseTime = parseDate((String) jsonInfo["releaseTime"])
+        try {
+            result.time = parseDate((String) jsonInfo["time"])
+        } catch (IllegalArgumentException ignored) {
+            // Ignore since these timestamps are not important for us right now
+        }
+        try {
+            result.releaseTime = parseDate((String) jsonInfo["releaseTime"])
+        } catch (IllegalArgumentException ignored) {
+            // Ignore since these timestamps are not important for us right now
+        }
         result.type = (String) jsonInfo["type"]
         result.processArguments = (String) jsonInfo["processArguments"]
         result.minecraftArguments = (String) jsonInfo["minecraftArguments"]

--- a/src/test/groovy/com/github/abrarsyed/gmcp/mcversion/McLibraryDependencyTest.groovy
+++ b/src/test/groovy/com/github/abrarsyed/gmcp/mcversion/McLibraryDependencyTest.groovy
@@ -1,0 +1,65 @@
+package com.github.abrarsyed.gmcp.mcversion
+
+import org.junit.Assert
+import org.junit.Test
+
+class McLibraryDependencyTest {
+
+    @Test
+    public void testAllowedNoRules() throws Exception {
+
+        // Dependency without rules should always be taken into consideration
+        testWithRules(true)
+
+    }
+
+    @Test
+    public void testAllowedSingleRule() throws Exception {
+
+        // A single rule that is allowed, the dependency should be allowed as well
+        testWithRules(true, true)
+
+    }
+
+    @Test
+    public void testDisallowedSingleRule() throws Exception {
+
+        // A single rule that is disallowed, the dependency should be skipped
+        testWithRules(false, false)
+
+    }
+
+    @Test
+    public void testDisallowAndAllow() throws Exception {
+
+        // Disallow should win over allow if multiple rules are specified
+        testWithRules(false, true, false)
+
+    }
+
+    private static void testWithRules(boolean expectedResult, boolean... allowOrDisallow) {
+
+        def dep = new McLibraryDependency()
+        for (mode in allowOrDisallow)
+            dep.rules.add(new MockedRule(mode))
+
+        Assert.assertEquals(expectedResult, dep.allowed)
+
+    }
+
+    private static class MockedRule extends McLibraryRule {
+
+        private final boolean allowed
+
+        MockedRule(boolean allowed) {
+            this.allowed = allowed
+        }
+
+        @Override
+        boolean isAllowed() {
+            return allowed
+        }
+
+    }
+
+}

--- a/src/test/groovy/com/github/abrarsyed/gmcp/mcversion/McLibraryRuleOsTest.groovy
+++ b/src/test/groovy/com/github/abrarsyed/gmcp/mcversion/McLibraryRuleOsTest.groovy
@@ -1,0 +1,58 @@
+package com.github.abrarsyed.gmcp.mcversion
+
+import com.github.abrarsyed.gmcp.Constants
+import com.github.abrarsyed.gmcp.Util
+import org.junit.Test
+
+import java.util.regex.Pattern
+
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertTrue
+
+class McLibraryRuleOsTest {
+
+    @Test
+    public void testMatchCurrentOs() throws Exception {
+        String expectedName = getCurrentOsName()
+
+        // Test for any version
+        def rule = new McLibraryRuleOs(expectedName, /^.*$/)
+        assertTrue(rule.match)
+
+        // Test with the exact version we have
+        rule = new McLibraryRuleOs(expectedName, Pattern.quote(System.getProperty("os.version")))
+        assertTrue(rule.match)
+    }
+
+    @Test
+    public void testNotMatchingCurrentOsName() {
+
+        def rule = new McLibraryRuleOs("Some Other OS Name", /^.*$/)
+        assertFalse(rule.match)
+
+    }
+
+    @Test
+    public void testNotMatchingCurrentOsVersion() {
+
+        def expectedName = getCurrentOsName()
+
+        // Test with the exact version we have
+        def rule = new McLibraryRuleOs(expectedName, "some-unrecognized-version")
+        assertFalse(rule.match)
+
+    }
+
+    private static String getCurrentOsName() {
+        switch (Util.OS) {
+            case Constants.OperatingSystem.WINDOWS:
+                return "windows"
+            case Constants.OperatingSystem.MAC:
+                return "osx"
+            case Constants.OperatingSystem.LINUX:
+                return "linux"
+        }
+        throw new IllegalStateException("Unknown OS: " + Util.OS)
+    }
+
+}

--- a/src/test/groovy/com/github/abrarsyed/gmcp/mcversion/McLibraryRuleTest.groovy
+++ b/src/test/groovy/com/github/abrarsyed/gmcp/mcversion/McLibraryRuleTest.groovy
@@ -1,0 +1,79 @@
+package com.github.abrarsyed.gmcp.mcversion
+
+import org.junit.Assert
+import org.junit.Test
+
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertTrue
+import static org.mockito.Mockito.doReturn
+import static org.mockito.Mockito.mock
+import static org.mockito.Mockito.when
+
+class McLibraryRuleTest {
+
+    @Test
+    void testAllowed() {
+
+        // Blanket allow
+        def rule = new McLibraryRule()
+        rule.action = "allow"
+        assertTrue(rule.allowed)
+
+    }
+
+    @Test
+    public void testDisallowed() throws Exception {
+
+        // Blanket disallow (which is not very useful)
+        def rule = new McLibraryRule()
+        rule.action = "disallow"
+        assertFalse(rule.allowed)
+
+    }
+
+    @Test
+    public void testDisallowWitOsRuleMatching() throws Exception {
+        testRuleWithOs("disallow", true, false)
+    }
+
+    @Test
+    public void testDisallowWitOsRuleNotMatching() throws Exception {
+        testRuleWithOs("disallow", false, true)
+    }
+
+    @Test
+    public void testAllowWitOsRuleMatching() throws Exception {
+        testRuleWithOs("allow", true, true)
+    }
+
+    @Test
+    public void testAllowWitOsRuleNotMatching() throws Exception {
+        testRuleWithOs("allow", false, false)
+    }
+
+    private void testRuleWithOs(String action, boolean osMatching, boolean expectedResult) {
+
+        def mockedOsRule = new MockedOsRule()
+        mockedOsRule.fixedMatch = osMatching
+
+        def rule = new McLibraryRule()
+        rule.action = action
+        rule.os = mockedOsRule
+        Assert.assertEquals(expectedResult, rule.allowed)
+
+    }
+
+    private static class MockedOsRule extends McLibraryRuleOs {
+        boolean fixedMatch
+
+        MockedOsRule() {
+            super("dontCare", "dontCare")
+        }
+
+        @Override
+        boolean isMatch() {
+            return fixedMatch
+        }
+    }
+
+}

--- a/src/test/groovy/com/github/abrarsyed/gmcp/mcversion/McVersionInfoTest.groovy
+++ b/src/test/groovy/com/github/abrarsyed/gmcp/mcversion/McVersionInfoTest.groovy
@@ -1,0 +1,72 @@
+package com.github.abrarsyed.gmcp.mcversion
+
+import com.google.common.io.Resources
+import org.junit.Test
+
+import javax.xml.bind.DatatypeConverter
+
+import static org.junit.Assert.*
+
+class McVersionInfoTest {
+
+    public static final String MC_1_6_2_INFO_URL = "https://s3.amazonaws.com/Minecraft.Download/versions/1.6.2/1.6.2.json"
+
+    @Test
+    public void testDownload() {
+        def info = McVersionInfo.parse(new URL(MC_1_6_2_INFO_URL));
+        assertEquals("1.6.2", info.id);
+    }
+
+    @Test
+    public void testParse() {
+
+        def jsonUrl = Resources.getResource(McVersionInfoTest.class, "/1.6.2.json")
+        def info = McVersionInfo.parse(jsonUrl);
+
+        assertEquals("1.6.2", info.id);
+        Calendar expected = DatatypeConverter.parseDate("2013-07-09T20:59:42+02:00");
+        assertEquals(expected, info.time);
+        expected = DatatypeConverter.parseDate("2013-07-05T15:09:02+02:00");
+        assertEquals(expected, info.releaseTime);
+        assertEquals("release", info.type);
+        assertEquals("username_session_version", info.processArguments);
+        assertEquals('--username ${auth_player_name} --session ${auth_session} --version ${version_name} --gameDir ${game_directory} --assetsDir ${game_assets}',
+                info.minecraftArguments);
+        assertEquals(4, info.minimumLauncherVersion);
+        assertEquals("net.minecraft.client.main.Main", info.mainClass);
+        assertEquals(3, info.libraries.size());
+
+        def library = info.libraries[0];
+        assertEquals("net.sf.jopt-simple:jopt-simple:4.5", library.name)
+        assertEquals(0, library.rules.size())
+
+        /*
+            This is the library that should be disallowed on anything but a certain version of OSX
+         */
+        library = info.libraries[1];
+        assertEquals("org.lwjgl.lwjgl:lwjgl-platform:2.9.0", library.name)
+        assertEquals(2, library.rules.size())
+
+        def rule = library.rules[0]
+        assertEquals("allow", rule.action)
+        assertNull(rule.os)
+
+        rule = library.rules[1]
+        assertEquals("disallow", rule.action)
+        assertEquals("osx", rule.os.name)
+        assertEquals(/^10\.5\.\d$/, rule.os.versionPattern.pattern())
+
+        /*
+            This is the library that should only be allowed on a certain version of OSX
+         */
+        library = info.libraries[2];
+        assertEquals("org.lwjgl.lwjgl:lwjgl-platform:2.9.1-nightly-20130708-debug3", library.name)
+        assertEquals(1, library.rules.size())
+
+        rule = library.rules[0]
+        assertEquals("allow", rule.action)
+        assertEquals("osx", rule.os.name)
+        assertEquals(/^10\.5\.\d$/, rule.os.versionPattern.pattern())
+    }
+
+}

--- a/src/test/resources/1.6.2.json
+++ b/src/test/resources/1.6.2.json
@@ -1,0 +1,63 @@
+
+{
+    "id": "1.6.2",
+    "time": "2013-07-09T20:59:42+02:00",
+    "releaseTime": "2013-07-05T15:09:02+02:00",
+    "type": "release",
+    "processArguments": "username_session_version",
+    "minecraftArguments": "--username ${auth_player_name} --session ${auth_session} --version ${version_name} --gameDir ${game_directory} --assetsDir ${game_assets}",
+    "minimumLauncherVersion": 4,
+    "libraries": [
+        {
+            "name": "net.sf.jopt-simple:jopt-simple:4.5"
+        },
+        {
+            "name": "org.lwjgl.lwjgl:lwjgl-platform:2.9.0",
+            "natives": {
+                "linux": "natives-linux",
+                "windows": "natives-windows",
+                "osx": "natives-osx"
+            },
+            "extract": {
+                "exclude": [
+                    "META-INF/"
+                ]
+            },
+            "rules": [
+                {
+                    "action": "allow"
+                },
+                {
+                    "action": "disallow",
+                    "os": {
+                        "name": "osx",
+                        "version": "^10\\.5\\.\\d$"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "org.lwjgl.lwjgl:lwjgl-platform:2.9.1-nightly-20130708-debug3",
+            "natives": {
+                "linux": "natives-linux",
+                "windows": "natives-windows",
+                "osx": "natives-osx"
+            },
+            "extract": {
+                "exclude": [
+                    "META-INF/"
+                ]
+            },
+            "rules": [
+                {
+                    "action": "allow",
+                    "os": {
+                        "name": "osx",
+                        "version": "^10\\.5\\.\\d$"
+                    }
+                }
+            ]
+        }
+    ],
+    "mainClass": "net.minecraft.client.main.Main"
+}


### PR DESCRIPTION
This pull request should add basic support for Minecraft 1.6

It does the following:
- Adds support to parse the Minecraft JSON blobs that specify library dependencies (with tests)
- Parses the JSON included with FML to add build dependencies and download natives to jars/bin/natives
- Fixes fixing the *.exc file (Contained some invalid java signatures in 1.6, it now skips processing those and writes them to the output mapping unchanged)
- Downloads the Minecraft client using the new URL format (URLs are no longer specified in FML config)

Current issues I know of:
- When switching MC versions, one has to do a manual removal of the build directory (clean doesnt seem to pick it up), since the extracted deobfuscated jar is still there and gets picked up by the decompiler. This causes compilation issues because MinecraftApplet and other classes are gone in 1.6
- Didn't test Eclipse integration (since i don't have it installed).

This should be considered a starting point however :-)
